### PR TITLE
feat(profile): Prefill and handle profile form with authenticated user data

### DIFF
--- a/src/app/(panel)/dashboard/profile/_components/profile-form.tsx
+++ b/src/app/(panel)/dashboard/profile/_components/profile-form.tsx
@@ -2,6 +2,14 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+interface UseProfileFormProps {
+  name: string | null;
+  adress: string | null;
+  phone: string | null;
+  status:  boolean;
+  timezone: string | null;
+}
+
 const profileSchema = z.object({
   name: z.string().min(1, { message: "Campo nome é necessário" }),
   adress: z.string().optional(),
@@ -12,16 +20,21 @@ const profileSchema = z.object({
 
 export type ProfileFormData = z.infer<typeof profileSchema>;
 
-export function useProfileForm() {
-    return useForm<ProfileFormData>(
-        {resolver: zodResolver(profileSchema),
-            defaultValues:{
-                name: "",
-                adress: "",
-                phone: "",
-                status: "",
-                timezone: "",
-            }
-        }
-    )
+export function useProfileForm({
+  name,
+  adress,
+  phone,
+  status,
+  timezone,
+}: UseProfileFormProps) {
+  return useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      name: name || "",
+      adress: adress || "",
+      phone: phone || "",
+      status: status ? "active" : "inactive",
+      timezone: timezone || "",
+    },
+  });
 }

--- a/src/app/(panel)/dashboard/profile/_components/profile-form.tsx
+++ b/src/app/(panel)/dashboard/profile/_components/profile-form.tsx
@@ -10,7 +10,7 @@ const profileSchema = z.object({
   timezone: z.string().min(1, { message: "Selecione o fuso horário" }),
 });
 
-type ProfileFormData = z.infer<typeof profileSchema>;
+export type ProfileFormData = z.infer<typeof profileSchema>;
 
 export function useProfileForm() {
     return useForm<ProfileFormData>(

--- a/src/app/(panel)/dashboard/profile/_components/profile.tsx
+++ b/src/app/(panel)/dashboard/profile/_components/profile.tsx
@@ -33,11 +33,30 @@ import { useState } from "react";
 import imgTest from "../../../../../../public/foto1.png";
 import { ProfileFormData, useProfileForm } from "./profile-form";
 import { DialogClose } from "@radix-ui/react-dialog";
+import { Prisma } from "@/generated/prisma";
 
-export function ProfileContent() {
-  const [selectedHours, setSelectedHours] = useState<string[]>([]);
+type UserWithSubscription = Prisma.UserGetPayload<{
+  include: {
+    subscription: true;
+  };
+}>;
 
-  const form = useProfileForm();
+interface ProfileContentProps {
+  user: UserWithSubscription;
+}
+
+export function ProfileContent({ user }: ProfileContentProps) {
+  const [selectedHours, setSelectedHours] = useState<string[]>(
+    user.times ?? []
+  );
+
+  const form = useProfileForm({
+    name: user.name,
+    adress: user.adress,
+    phone: user.phone,
+    status: user.status,
+    timezone: user.timezone,
+  });
 
   function generateTimeSlots(): string[] {
     const hours: string[] = [];

--- a/src/app/(panel)/dashboard/profile/_components/profile.tsx
+++ b/src/app/(panel)/dashboard/profile/_components/profile.tsx
@@ -1,5 +1,5 @@
 "use client";
-import * as button from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
@@ -31,7 +31,8 @@ import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
 import imgTest from "../../../../../../public/foto1.png";
-import { useProfileForm } from "./profile-form";
+import { ProfileFormData, useProfileForm } from "./profile-form";
+import { DialogClose } from "@radix-ui/react-dialog";
 
 export function ProfileContent() {
   const [selectedHours, setSelectedHours] = useState<string[]>([]);
@@ -77,10 +78,18 @@ export function ProfileContent() {
       zone.startsWith("America/Rio_Branco")
   );
 
+  async function onSubmit(values: ProfileFormData) {
+    const profileData = {
+      ...values,
+      times: selectedHours,
+    };
+    console.log(profileData);
+  }
+
   return (
     <div>
       <Form {...form}>
-        <form>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
           <Card>
             <CardHeader>
               <CardTitle>Minha Clínica</CardTitle>
@@ -166,7 +175,7 @@ export function ProfileContent() {
                           onValueChange={field.onChange}
                           defaultValue={field.value ? "active" : "ínactive"}
                         >
-                          <SelectTrigger className="text-base">
+                          <SelectTrigger className="w-full">
                             <SelectValue placeholder="Selecione o status da clínica" />
                           </SelectTrigger>
 
@@ -190,13 +199,13 @@ export function ProfileContent() {
 
                   <Dialog>
                     <DialogTrigger asChild>
-                      <button.Button
+                      <Button
                         variant="outline"
                         className="w-full justify-between font-light"
                       >
-                        Clique aqui para selecionar Horarios{" "}
+                        Clique aqui para selecionar horários{" "}
                         <ArrowRight className="w-5 h-5" />
-                      </button.Button>
+                      </Button>
                     </DialogTrigger>
 
                     <DialogContent>
@@ -214,7 +223,7 @@ export function ProfileContent() {
 
                         <div className="grid grid-cols-5 gap-2">
                           {hours.map((hour) => (
-                            <button.Button
+                            <Button
                               key={hour}
                               variant="outline"
                               className={cn(
@@ -227,10 +236,13 @@ export function ProfileContent() {
                               }}
                             >
                               {hour}
-                            </button.Button>
+                            </Button>
                           ))}
                         </div>
                       </section>
+                      <DialogClose className="w-full bg-black text-white rounded-sm h-10">
+                        Fechar
+                      </DialogClose>
                     </DialogContent>
                   </Dialog>
                 </div>
@@ -250,7 +262,7 @@ export function ProfileContent() {
                           onValueChange={field.onChange}
                           defaultValue={field.value}
                         >
-                          <SelectTrigger className="text-base">
+                          <SelectTrigger className="w-full">
                             <SelectValue placeholder="Selecione seu fuso horário" />
                           </SelectTrigger>
 
@@ -268,6 +280,9 @@ export function ProfileContent() {
                   )}
                 />
               </div>
+              <Button className="w-full bg-emerald-500 hover:bg-emerald-400 hover:text-gray-500">
+                Salvar alterações
+              </Button>
             </CardContent>
           </Card>
         </form>

--- a/src/app/(panel)/dashboard/profile/page.tsx
+++ b/src/app/(panel)/dashboard/profile/page.tsx
@@ -14,7 +14,7 @@ export default async function Profile() {
 
   return (
     <section>
-      <ProfileContent/>
+      <ProfileContent user={user}/>
     </section>
   );
 }


### PR DESCRIPTION
## Overview
This PR prepares the profile form to work with user data obtained from authentication (currently via GitHub). It maps user attributes into a typed form structure, pre-fills the form with these values, and enables submission handling in local state.

## Key Changes
- **Data Retrieval**
  - Retrieved `user` object in `profile/page.tsx`
  - Passed user data as argument to `ProfileContent` component
- **Form Preparation**
  - Updated `useProfileForm` to accept user attributes as parameters
  - Created `ProfileFormData` interface with nullable attributes for type mapping
- **Form Integration**
  - Passed user attributes from `ProfileContent` into `useProfileForm` for pre-filled values
  - Displayed authenticated user data inside the profile form
- **Form Submission**
  - Added `onSubmit` async function using `form.handleSubmit()`
  - Submission currently handled in local state only
  - Applied `ProfileFormData` type to submitted values

## Technical Impact
- Allows authenticated user data to be displayed and edited in the profile form
- Establishes a typed structure for form state management
- Lays groundwork for future persistence of profile updates

## Testing Checklist
- [x] Confirm authenticated user data is retrieved in `profile/page.tsx` and passed correctly
- [x] Verify `useProfileForm` initializes with provided user attributes
- [x] Ensure form fields are pre-filled with existing user data
- [x] Test that form submission captures changes in local state
- [x] Check type safety through `ProfileFormData` during submission
